### PR TITLE
Update syntax.php (removed utf8_encode)

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -121,7 +121,7 @@ class syntax_plugin_sqlcomp extends DokuWiki_Syntax_Plugin {
      */
     public function render($mode, Doku_Renderer $renderer, $data) {
         if($mode != 'xhtml') return false;
-        $renderer->doc .= utf8_encode($this->_query($data));
+        $renderer->doc .= $this->_query($data);
         return true;
     }
 


### PR DESCRIPTION
Removing utf8_encode, because the most dbs return utf8.